### PR TITLE
Set Redis.logger only if debug setting is true

### DIFF
--- a/lib/pooled_redis.rb
+++ b/lib/pooled_redis.rb
@@ -31,7 +31,7 @@ module PooledRedis
     @redis_config = begin
       config = ActiveRecord::Base.connection_config[:redis].with_indifferent_access
       config[:driver] ||= :hiredis if defined?(Hiredis)
-      config[:logger] = Rails.logger if Rails.env.development?
+      config[:logger] = Rails.logger if config.delete(:debug)
       config
     end
   end


### PR DESCRIPTION
Hi,

I've found hard coding logging setting in development environment isn't really convenient for most cases. So I thought that it would be better if user could turn on logging only when he really needs it, just like this:

``` yaml
development:
  redis:
    host: localhost
    port: 6379
    debug: true
```
