### PR TITLE
Added support for Redis::Namespace

### DIFF
--- a/lib/pooled_redis.rb
+++ b/lib/pooled_redis.rb
@@ -26,11 +26,42 @@ ConnectionPool.class_eval do
 end
 
 module PooledRedis
+  class << self
+    def setup_rails_cache(app)
+      # We need to use initializer to be able to access
+      # Rails.configuration.database_configuration.
+      app.initializer :configure_cache, before: :initialize_cache, group: :all do
+        cache_config = Rails.configuration.
+            database_configuration[Rails.env]['cache'].try!(:with_indifferent_access)
+        adapter = cache_config.try!(:delete, :adapter).try!(:to_sym)
+        next unless adapter
+        if adapter == :redis_store
+          # Workaround to support `:db` option:
+          pool_config ||= {
+              pool:     cache_config.delete(:pool)    || 5,
+              timeout:  cache_config.delete(:timeout) || 5,
+          }
+          cache_config = {
+              pool: ConnectionPool.new(pool_config) { Redis::Store.new(cache_config) }
+          }
+        end
+        app.config.cache_store = adapter, cache_config
+      end
+    end
+  end
+
   # Override this method unless using Rails.
   def redis_config
-    @redis_config = begin
+    @redis_config ||= begin
       config = ActiveRecord::Base.connection_config[:redis].with_indifferent_access
       config[:logger] = Rails.logger if config.delete(:debug)
+
+      if config.key?(:namespace)
+        # ensure gem is installed
+        gem 'redis-namespace'
+        require 'redis/namespace'
+      end
+
       config
     end
   end
@@ -43,34 +74,19 @@ module PooledRedis
   end
 
   def redis_pool
-    @redis_pool ||= ConnectionPool.new(redis_pool_config) { Redis.new(redis_config) }
+    @redis_pool ||= ConnectionPool.new(redis_pool_config) { instantiate_redis }
   end
 
   def redis
     @redis ||= redis_pool.simple_connection
   end
 
-  class << self
-    def setup_rails_cache(app)
-      # We need to use initializer to be able to access
-      # Rails.configuration.database_configuration.
-      app.initializer :configure_cache, before: :initialize_cache, group: :all do
-        cache_config = Rails.configuration.
-          database_configuration[Rails.env]['cache'].try!(:with_indifferent_access)
-        adapter = cache_config.try!(:delete, :adapter).try!(:to_sym)
-        next unless adapter
-        if adapter == :redis_store
-          # Workaround to support `:db` option:
-          pool_config ||= {
-            pool:     cache_config.delete(:pool)    || 5,
-            timeout:  cache_config.delete(:timeout) || 5,
-          }
-          cache_config = {
-            pool: ConnectionPool.new(pool_config) { Redis::Store.new(cache_config) }
-          }
-        end
-        app.config.cache_store = adapter, cache_config
-      end
+  private
+  def instantiate_redis
+    if redis_config.key?(:namespace)
+      Redis::Namespace.new(redis_config[:namespace], redis_config)
+    else
+      Redis.new(redis_config)
     end
   end
 end


### PR DESCRIPTION
Now it is possible to setup namespaced redis in config/database.yml:

```
development:
  redis:
    host: localhost
    namespace: my_app
```

I believe it could be useful feature on deployments with shared redis instance.
