### PR TITLE
Fixed pool initialization with Redis::Namespace

### DIFF
--- a/lib/pooled_redis.rb
+++ b/lib/pooled_redis.rb
@@ -85,7 +85,7 @@ module PooledRedis
       block = if redis_config[:block]
         redis_config[:block]
       elsif redis_config[:namespace]
-        -> { Redis::Namespace.new(redis_config[:namespace], redis_config) }
+        -> { Redis::Namespace.new(redis_config[:namespace], redis: Redis.new(redis_config)) }
       else
         -> { Redis.new(redis_config) }
       end


### PR DESCRIPTION
Today I've found out dramatic performance degradation in my sidekiq workers because of wrong initialization of Redis::Namespace within ConnectionPool.

Here is constructor from Redis::Namespace class:

``` ruby
    def initialize(namespace, options = {})
      @namespace = namespace
      @redis = options[:redis] || Redis.current
      @warning = !!options.fetch(:warning) do
                   !ENV['REDIS_NAMESPACE_QUIET']
                 end
      @deprecations = !!options.fetch(:deprecations) do
                        ENV['REDIS_NAMESPACE_DEPRECATIONS']
                      end
    end
```

`Redis.current` doesn't work with ConnectionPool. I've fixed this but failed to write proper specs. I've tested it with my current project and it seems that after this fix Sidekiq performance is high again. 
